### PR TITLE
Add a custom timeout option for cog worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ARG COG_VERSION
 
 FROM r8.im/${COG_REPO}/${COG_MODEL}@sha256:${COG_VERSION}
 
-ARG REQUEST_TIMEOUT=600
-ENV REQUEST_TIMEOUT=${REQUEST_TIMEOUT}
+ENV REQUEST_TIMEOUT=600
 
 # Install necessary packages and Python 3.10
 RUN apt-get update && apt-get upgrade -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 ARG COG_REPO
 ARG COG_MODEL
 ARG COG_VERSION
+ARG REQUEST_TIMEOUT=600
 
 FROM r8.im/${COG_REPO}/${COG_MODEL}@sha256:${COG_VERSION}
+
+ENV REQUEST_TIMEOUT=${REQUEST_TIMEOUT}
 
 # Install necessary packages and Python 3.10
 RUN apt-get update && apt-get upgrade -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 ARG COG_REPO
 ARG COG_MODEL
 ARG COG_VERSION
-ARG REQUEST_TIMEOUT=600
 
 FROM r8.im/${COG_REPO}/${COG_MODEL}@sha256:${COG_VERSION}
 
-ENV REQUEST_TIMEOUT=${REQUEST_TIMEOUT}
+ENV REQUEST_TIMEOUT=600
 
 # Install necessary packages and Python 3.10
 RUN apt-get update && apt-get upgrade -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ARG COG_VERSION
 
 FROM r8.im/${COG_REPO}/${COG_MODEL}@sha256:${COG_VERSION}
 
-ENV REQUEST_TIMEOUT=600
+ARG REQUEST_TIMEOUT=600
+ENV REQUEST_TIMEOUT=${REQUEST_TIMEOUT}
 
 # Install necessary packages and Python 3.10
 RUN apt-get update && apt-get upgrade -y && \

--- a/src/handler.py
+++ b/src/handler.py
@@ -6,11 +6,13 @@ import runpod
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+TIMEOUT = int(os.environ.get("REQUEST_TIMEOUT", "600"))
+
 LOCAL_URL = "http://127.0.0.1:5000"
 
 cog_session = requests.Session()
 retries = Retry(total=10, backoff_factor=0.1, status_forcelist=[502, 503, 504])
-cog_session.mount('http://', HTTPAdapter(max_retries=retries))
+cog_session.mount("http://", HTTPAdapter(max_retries=retries))
 
 
 # ----------------------------- Start API Service ---------------------------- #
@@ -22,9 +24,9 @@ subprocess.Popen(["python", "-m", "cog.server.http"])
 #                              Automatic Functions                             #
 # ---------------------------------------------------------------------------- #
 def wait_for_service(url):
-    '''
+    """
     Check if the service is ready to receive requests.
-    '''
+    """
     while True:
         try:
             health = requests.get(url, timeout=120)
@@ -43,12 +45,17 @@ def wait_for_service(url):
 
 
 def run_inference(inference_request):
-    '''
+    """
     Run inference on a request.
-    '''
-    response = cog_session.post(url=f'{LOCAL_URL}/predictions',
-                                json=inference_request, 
-                                timeout=int(os.environ.get("REQUEST_TIMEOUT",600)))
+    """
+    response = cog_session.post(
+        url=f"{LOCAL_URL}/predictions",
+        json=inference_request,
+        timeout=int(os.environ.get("REQUEST_TIMEOUT", 600)),
+    )
+    if response.status_code != 200:
+        print(response.status_code)
+        print(response.text)
     return response.json()
 
 
@@ -56,9 +63,9 @@ def run_inference(inference_request):
 #                                RunPod Handler                                #
 # ---------------------------------------------------------------------------- #
 def handler(event):
-    '''
+    """
     This is the handler function that will be called by the serverless.
-    '''
+    """
 
     json = run_inference({"input": event["input"]})
 
@@ -66,8 +73,10 @@ def handler(event):
 
 
 if __name__ == "__main__":
-    wait_for_service(url=f'{LOCAL_URL}/health-check')
+    wait_for_service(url=f"{LOCAL_URL}/health-check")
 
     print("Cog API Service is ready. Starting RunPod serverless handler...")
+    if TIMEOUT != 600:
+        print(f"Using non-default timeout of {TIMEOUT}s")
 
     runpod.serverless.start({"handler": handler})

--- a/src/handler.py
+++ b/src/handler.py
@@ -6,7 +6,7 @@ import runpod
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-TIMEOUT = int(os.environ.get("REQUEST_TIMEOUT", "600"))
+TIMEOUT = int(os.environ.get("_RUNPOD_REQUEST_TIMEOUT", "600"))
 
 LOCAL_URL = "http://127.0.0.1:5000"
 
@@ -51,7 +51,7 @@ def run_inference(inference_request):
     response = cog_session.post(
         url=f"{LOCAL_URL}/predictions",
         json=inference_request,
-        timeout=int(os.environ.get("REQUEST_TIMEOUT", 600)),
+        timeout=TIMEOUT,
     )
     if response.status_code != 200:
         print(response.status_code)

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,5 +1,6 @@
 import time
 import subprocess
+import os
 
 import runpod
 import requests
@@ -46,7 +47,8 @@ def run_inference(inference_request):
     Run inference on a request.
     '''
     response = cog_session.post(url=f'{LOCAL_URL}/predictions',
-                                json=inference_request, timeout=600)
+                                json=inference_request, 
+                                timeout=int(os.environ.get("REQUEST_TIMEOUT",600)))
     return response.json()
 
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -56,6 +56,7 @@ def run_inference(inference_request):
     if response.status_code != 200:
         print(response.status_code)
         print(response.text)
+    print(response.text)
     return response.json()
 
 
@@ -76,7 +77,6 @@ if __name__ == "__main__":
     wait_for_service(url=f"{LOCAL_URL}/health-check")
 
     print("Cog API Service is ready. Starting RunPod serverless handler...")
-    if TIMEOUT != 600:
-        print(f"Using non-default timeout of {TIMEOUT}s")
+    print(f"Using request timeout of {TIMEOUT}s")
 
     runpod.serverless.start({"handler": handler})


### PR DESCRIPTION
Modified the image to have a environment variable to set the timeout for cog workers. This is helpful when running longer operations, like those for video face-swap, lip-sync, etc. Still set to timeout at 600s by default. Option can be modified in the runpod serverless template.